### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clear_old_posts.yml
+++ b/.github/workflows/clear_old_posts.yml
@@ -1,5 +1,8 @@
 name: Prune Posts and Archive
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/.github/workflows/request_landing.yml
+++ b/.github/workflows/request_landing.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   comment:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/trigger_main_site.yml
+++ b/.github/workflows/trigger_main_site.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'posts/**'
 
+permissions:
+  contents: read
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate_post.yml
+++ b/.github/workflows/validate_post.yml
@@ -1,4 +1,6 @@
 name: Validate Jekyll Posts
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/zunalita/posts/security/code-scanning/4](https://github.com/zunalita/posts/security/code-scanning/4)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow only needs to read repository contents (to check out code and read files), so `contents: read` is sufficient. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job needs different permissions. The change should be made at the top of `.github/workflows/validate_post.yml`, after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
